### PR TITLE
Feature/de1 etl transform facts

### DIFF
--- a/data-engineering/pipeline/transform/transform_quality_metrics.py
+++ b/data-engineering/pipeline/transform/transform_quality_metrics.py
@@ -304,7 +304,7 @@ def transform_quality_payload(extracted: ExtractedPayload) -> TransformedPayload
     LOGGER.info(
         (
             "Transformation complete. dim_datasets=%s dim_rules=%s "
-            "fact_checks=%s fact_scores=%s dim_date=%s rows_extracted=%s"
+            "fact_checks=%s fact_scores=%s dim_date=%s rows_extracted=%s target_watermark=%s"
         ),
         len(dim_datasets),
         len(dim_rules),
@@ -312,6 +312,7 @@ def transform_quality_payload(extracted: ExtractedPayload) -> TransformedPayload
         len(fact_quality_scores),
         len(dim_date),
         rows_extracted,
+        extracted.max_source_timestamp,
     )
     return TransformedPayload(
         dim_datasets=dim_datasets,


### PR DESCRIPTION
Completes transform logic for fact tables and date dimension. Adds      
  builders for fact_quality_checks, fact_quality_scores, and dim_date,    
  including derived metrics (failure_rate, bounded score values, date_key)  and final wiring of full transformed output.