### PR TITLE
feat: Add Prometheus /metrics endpoint for monitoring

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,6 +25,9 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# Initialize and expose Prometheus metrics
+Instrumentator().instrument(app).expose(app)
+
 app.add_middleware(GlobalLoggingMiddleware)
 app.add_middleware(
     CORSMiddleware,

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,11 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_metrics_endpoint():
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "http_requests_total" in response.text
+    assert "process_virtual_memory_bytes" in response.text


### PR DESCRIPTION
## What you changed:
- Added prometheus-fastapi-instrumentator to the project's dependencies (requirements.txt).
- Imported and configured the Instrumentator in backend/app/main.py.
- Initialized and exposed the /metrics endpoint within the main FastAPI application instance.
- Created test_metrics_endpoint  in backend/tests/test_main.py  to ensure the endpoint functions correctly and returns expected Prometheus metrics like HTTP request counts and memory usage.

## Why: 

- To enable application monitoring and observability. Exposing a /metrics endpoint allows Prometheus to scrape essential system metrics (such as request patterns, active connections, and hardware metrics), which is critical for setting up monitoring dashboards and performance alerts for the backend.

## How to test it:

Automated Tests: Run the test suite using pytest to verify the endpoint is securely exposed and returning a 200 OK:
```
pytest tests/test_main.py
```

## Manual Verification:
- Start the server using docker-compose up --build
- Navigate your browser or use curl to visit http://127.0.0.1:8000/metrics.
- You should see plain text output showing data like http_requests_total and process_virtual_memory_bytes generated by the Prometheus client.